### PR TITLE
Changed how the Electron framework version is detected:

### DIFF
--- a/detect-electron-apps-by-version.sh
+++ b/detect-electron-apps-by-version.sh
@@ -1,32 +1,26 @@
 # Detect affected Electron versions
 mdfind "kMDItemFSName == '*.app'" | while read app; do
-  electronFiles=$(find "$app" -name "Electron Framework" -type f 2>/dev/null)
-  
-  if [[ -n "$electronFiles" ]]; then
-    appName=$(basename "$app")
-    
-    while IFS= read -r filename; do
-      electronVersion=$(strings "$filename" | grep "Chrome/" | grep -i Electron | grep -v '%s' | sort -u | cut -f 3 -d '/')
-      
-      if [[ -n "$electronVersion" ]]; then
-        IFS='.' read -r major minor patch <<< "$electronVersion"
-        
-        relativePath=$(echo "$filename" | sed "s|$app/||")
-        
-        if [[ $major -gt 39 ]] || \
-           [[ $major -eq 39 && $minor -ge 0 ]] || \
-           [[ $major -eq 38 && $minor -gt 2 ]] || \
-           [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
-           [[ $major -eq 37 && $minor -gt 6 ]] || \
-           [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
-           [[ $major -eq 36 && $minor -gt 9 ]] || \
-           [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]; then
-          echo "✅ $appName: Electron $electronVersion ($relativePath)"
-        else
-          echo "❌ $appName: Electron $electronVersion ($relativePath)"
-        fi
-        break
+  appName=$(basename "$app")
+  electronFrameworkInfo="$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist"
+  if [[ -f "$electronFrameworkInfo" ]]; then
+    electronVersion=$(plutil -extract CFBundleVersion raw "$electronFrameworkInfo")
+      if [[ $? -eq 1 || -z "$electronVersion" ]]; then
+      echo "⚠️  $appName (No Electron version)"
+    else
+      IFS='.' read -r major minor patch <<< "$electronVersion"
+          
+      if [[ $major -gt 39 ]] || \
+        [[ $major -eq 39 && $minor -ge 0 ]] || \
+        [[ $major -eq 38 && $minor -gt 2 ]] || \
+        [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
+        [[ $major -eq 37 && $minor -gt 6 ]] || \
+        [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
+        [[ $major -eq 36 && $minor -gt 9 ]] || \
+        [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]; then
+        echo "✅ $appName ($electronVersion)"
+      else
+        echo "❌️ $appName ($electronVersion)"
       fi
-    done <<< "$electronFiles"
+    fi
   fi
 done


### PR DESCRIPTION
• The `strings` command is only available when Xcode is installed - this prevents normal folks from using the script
• Extracting the version from the framework's Info.plist is faster