### PR TITLE
Speed up script and mark apps that are running

### DIFF
--- a/detect-affected-electron-apps.sh
+++ b/detect-affected-electron-apps.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+running_procs=$(ps -eo comm= | sed 's|.*/||' | sort -u)
+
+check_electron_version() {
+    local major=$1 minor=$2 patch=$3
+    [[ $major -gt 39 ]] || \
+    [[ $major -eq 39 && $minor -ge 0 ]] || \
+    [[ $major -eq 38 && $minor -gt 2 ]] || \
+    [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
+    [[ $major -eq 37 && $minor -gt 6 ]] || \
+    [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
+    [[ $major -eq 36 && $minor -gt 9 ]] || \
+    [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]
+}
+
+# Use ripgrep when available
+search_cmd="grep -aqF"
+if command -v rg &>/dev/null; then
+    search_cmd="rg -q --text -F"
+fi
+
+process_app() {
+    local app="$1"
+    local appName
+    appName=$(basename "$app")
+    local appNameNoExt="${appName%.app}"
+
+    local runningStatus
+    if echo "$RUNNING_PROCS" | grep -Fxq "$appNameNoExt"; then
+        runningStatus="🔵"
+    else
+        runningStatus="⚪️"
+    fi
+
+    local electronVersion
+    electronVersion=$(plutil -extract CFBundleVersion raw "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" 2>/dev/null)
+
+    local versionVulnerable
+    if [[ -z "$electronVersion" ]]; then
+        versionVulnerable=true
+        electronVersion="unknown"
+    else
+        # Split version string on dots (e.g., "37.6.0" → major=37, minor=6, patch=0)
+        IFS='.' read -r major minor patch <<< "$electronVersion"
+        if check_electron_version "$major" "$minor" "$patch"; then
+            versionVulnerable=false
+        else
+            versionVulnerable=true
+        fi
+    fi
+
+    local electronBinary="$app/Contents/Frameworks/Electron Framework.framework/Electron Framework"
+    local status
+    if [[ "$versionVulnerable" == true ]]; then
+        # Apps with both old version AND _cornerMask binary symbol are affected
+        if [[ -f "$electronBinary" ]] && $SEARCH_CMD "_cornerMask" "$electronBinary" 2>/dev/null; then
+            status="⚠️"
+        else
+            status="🔄"
+        fi
+    else
+        status="✅"
+    fi
+
+    echo "$runningStatus|$status|$appName|$electronVersion"
+}
+
+# Export functions and variables so xargs subshells can access them
+export -f process_app
+export -f check_electron_version
+export RUNNING_PROCS="$running_procs"
+export SEARCH_CMD="$search_cmd"
+
+{
+    mdfind "kMDItemFSName == '*.app'" 2>/dev/null | while IFS= read -r app; do
+        if [[ -f "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" ]]; then
+            echo "$app"
+        fi
+    done
+    # -P 0 runs unlimited parallel processes, _ is placeholder for $0, {} becomes $1
+} | xargs -P 0 -I {} bash -c 'process_app "$1"' _ '{}' | {
+    all_data=$(cat)
+
+    max_app_len=0
+    while IFS='|' read -r _ _ app _; do
+        len=${#app}
+        [[ $len -gt $max_app_len ]] && max_app_len=$len
+    done <<< "$all_data"
+
+    echo "$all_data" | sort -t'|' -k3 | while IFS='|' read -r running status app version; do
+        printf "%-3s  %-3s  %-${max_app_len}s  %s\n" "$running" "$status" "$app" "$version"
+    done
+
+    echo
+    echo "🔵 = Running, ⚪️ = Not running"
+    echo "✅ = Updated, 🔄 = Outdated, ⚠️ = Affected (contains _cornerMask)"
+}

--- a/detect-electron-apps-by-version.sh
+++ b/detect-electron-apps-by-version.sh
@@ -1,46 +1,27 @@
 #!/usr/bin/env bash
-
-running_procs=$(ps -eo comm= | sed 's|.*/||' | sort -u)
-
-check_electron_version() {
-    local major=$1 minor=$2 patch=$3
-    [[ $major -gt 39 ]] || \
-    [[ $major -eq 39 && $minor -ge 0 ]] || \
-    [[ $major -eq 38 && $minor -gt 2 ]] || \
-    [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
-    [[ $major -eq 37 && $minor -gt 6 ]] || \
-    [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
-    [[ $major -eq 36 && $minor -gt 9 ]] || \
-    [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]
-}
-
 # Detect affected Electron versions
-mdfind "kMDItemFSName == '*.app'" 2>/dev/null | sort | while IFS= read -r app; do
-    [[ -f "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" ]] || continue
-
-    appName=$(basename "$app")
-    appNameNoExt="${appName%.app}"
-
-    # Check if running (faster lookup)
-    if grep -Fxq "$appNameNoExt" <<< "$running_procs"; then
-        runningStatus="🔵"
+find /Applications /System/Applications ~/Applications -name "*.app" -type d 2>/dev/null | sort --ignore-case | while read -r app; do
+  appName=$(basename "$app")
+  electronFrameworkInfo="$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist"
+  if [[ -f "$electronFrameworkInfo" ]]; then
+    electronVersion=$(plutil -extract CFBundleVersion raw "$electronFrameworkInfo")
+      if [[ $? -eq 1 || -z "$electronVersion" ]]; then
+      echo "⚠️  $appName (No Electron version)"
     else
-        runningStatus="⚪️"
+      IFS='.' read -r major minor patch <<< "$electronVersion"
+          
+      if [[ $major -gt 39 ]] || \
+        [[ $major -eq 39 && $minor -ge 0 ]] || \
+        [[ $major -eq 38 && $minor -gt 2 ]] || \
+        [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
+        [[ $major -eq 37 && $minor -gt 6 ]] || \
+        [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
+        [[ $major -eq 36 && $minor -gt 9 ]] || \
+        [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]; then
+        echo "✅ $appName ($electronVersion)"
+      else
+        echo "❌️ $appName ($electronVersion)"
+      fi
     fi
-
-    # Get version
-    electronVersion=$(plutil -extract CFBundleVersion raw "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" 2>/dev/null)
-
-    if [[ -z "$electronVersion" ]]; then
-        echo "$runningStatus ⚠️  $appName (No Electron version)"
-        continue
-    fi
-
-    IFS='.' read -r major minor patch <<< "$electronVersion"
-
-    if check_electron_version "$major" "$minor" "$patch"; then
-        echo "$runningStatus ✅ $appName ($electronVersion)"
-    else
-        echo "$runningStatus ❌ $appName ($electronVersion)"
-    fi
+  fi
 done

--- a/detect-electron-apps-by-version.sh
+++ b/detect-electron-apps-by-version.sh
@@ -1,27 +1,46 @@
 #!/usr/bin/env bash
+
+running_procs=$(ps -eo comm= | sed 's|.*/||' | sort -u)
+
+check_electron_version() {
+    local major=$1 minor=$2 patch=$3
+    [[ $major -gt 39 ]] || \
+    [[ $major -eq 39 && $minor -ge 0 ]] || \
+    [[ $major -eq 38 && $minor -gt 2 ]] || \
+    [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
+    [[ $major -eq 37 && $minor -gt 6 ]] || \
+    [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
+    [[ $major -eq 36 && $minor -gt 9 ]] || \
+    [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]
+}
+
 # Detect affected Electron versions
-find /Applications /System/Applications ~/Applications -name "*.app" -type d 2>/dev/null | sort --ignore-case | while read -r app; do
-  appName=$(basename "$app")
-  electronFrameworkInfo="$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist"
-  if [[ -f "$electronFrameworkInfo" ]]; then
-    electronVersion=$(plutil -extract CFBundleVersion raw "$electronFrameworkInfo")
-      if [[ $? -eq 1 || -z "$electronVersion" ]]; then
-      echo "⚠️  $appName (No Electron version)"
+mdfind "kMDItemFSName == '*.app'" 2>/dev/null | sort | while IFS= read -r app; do
+    [[ -f "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" ]] || continue
+
+    appName=$(basename "$app")
+    appNameNoExt="${appName%.app}"
+
+    # Check if running (faster lookup)
+    if grep -Fxq "$appNameNoExt" <<< "$running_procs"; then
+        runningStatus="🔵"
     else
-      IFS='.' read -r major minor patch <<< "$electronVersion"
-          
-      if [[ $major -gt 39 ]] || \
-        [[ $major -eq 39 && $minor -ge 0 ]] || \
-        [[ $major -eq 38 && $minor -gt 2 ]] || \
-        [[ $major -eq 38 && $minor -eq 2 && $patch -ge 0 ]] || \
-        [[ $major -eq 37 && $minor -gt 6 ]] || \
-        [[ $major -eq 37 && $minor -eq 6 && $patch -ge 0 ]] || \
-        [[ $major -eq 36 && $minor -gt 9 ]] || \
-        [[ $major -eq 36 && $minor -eq 9 && $patch -ge 2 ]]; then
-        echo "✅ $appName ($electronVersion)"
-      else
-        echo "❌️ $appName ($electronVersion)"
-      fi
+        runningStatus="⚪️"
     fi
-  fi
+
+    # Get version
+    electronVersion=$(plutil -extract CFBundleVersion raw "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" 2>/dev/null)
+
+    if [[ -z "$electronVersion" ]]; then
+        echo "$runningStatus ⚠️  $appName (No Electron version)"
+        continue
+    fi
+
+    IFS='.' read -r major minor patch <<< "$electronVersion"
+
+    if check_electron_version "$major" "$minor" "$patch"; then
+        echo "$runningStatus ✅ $appName ($electronVersion)"
+    else
+        echo "$runningStatus ❌ $appName ($electronVersion)"
+    fi
 done


### PR DESCRIPTION
This performance problem angers me since I already dislike the laziness and non-nativeness of electron apps, so I further improved the scripts way beyond reason, combined them, and made them faster and sorted since I expect I'll be running this often for a long time (or until Apple addresses it in Tahoe).

It's also just plain helpful to find who's using Electron!

Example:
```
🔵  ✅  1Password.app           37.6.1
⚪️  ⚠️  AnythingLLM.app         31.7.7
⚪️  ⚠️  Bruno.app               31.2.1
🔵  ✅  Claude.app              37.6.0
⚪️  🔄  Components.app          4.0.0
⚪️  🔄  Discord.app             35.3.0+wvcus
⚪️  ⚠️  Dropbox.app             13.1.0-dropbox.20221010.faa890d59
⚪️  🔄  Electron APIs.app       unknown
⚪️  ⚠️  Lens.app                12.2.2
🔵  ⚠️  Liner.app               13.6.8
⚪️  ⚠️  LM Studio.app           24.8.8
⚪️  🔄  Material Colors.app     unknown
⚪️  ⚠️  Notion Mail.app         35.7.5
⚪️  ✅  Notion.app              37.6.0
⚪️  ✅  Obsidian.app            37.6.0
⚪️  ⚠️  Podman Desktop.app      27.0.1
⚪️  ⚠️  satyrn.app              28.3.3
⚪️  ⚠️  SideQuest.app           13.5.1
⚪️  ✅  Signal.app              38.2.1
⚪️  ✅  Slack.app               38.2.1
⚪️  ✅  Spark Desktop.app       36.9.5
⚪️  ⚠️  Upscayl.app             27.3.10
⚪️  ✅  Visual Studio Code.app  37.6.0

🔵 = Running, ⚪️ = Not running
✅ = Updated, 🔄 = Outdated, ⚠️ = Affected (contains _cornerMask)
```