### PR TITLE
Improve accuracy of detections of nested frameworks and running processes

### DIFF
--- a/detect-running-affected-electron-apps.sh
+++ b/detect-running-affected-electron-apps.sh
@@ -10,7 +10,6 @@ if [[ "$1" == "--fast" ]]; then
     FAST_MODE=true
 fi
 
-running_procs=$(ps -eo comm= | sed 's|.*/||' | sort -u)
 
 check_electron_version() {
     local major=$1 minor=$2 patch=$3
@@ -50,7 +49,9 @@ process_app() {
     local appNameNoExt="${appName%.app}"
 
     local runningStatus
-    if echo "$RUNNING_PROCS" | grep -Fxq "$appNameNoExt"; then
+    # Use pgrep for accurate detection of running apps
+    # Check if ANY executable from the app's MacOS directory is running
+    if pgrep -f "^$app/Contents/MacOS/" >/dev/null 2>&1; then
         runningStatus="🔵"
     else
         runningStatus="⚪️"
@@ -92,7 +93,6 @@ process_app() {
 # Export functions and variables so xargs subshells can access them
 export -f process_app
 export -f check_electron_version
-export RUNNING_PROCS="$running_procs"
 export SEARCH_CMD="$search_cmd"
 export EXTRACT_CMD="$extract_cmd"
 export FIND_CMD="$find_cmd"

--- a/detect-running-affected-electron-apps.sh
+++ b/detect-running-affected-electron-apps.sh
@@ -31,7 +31,7 @@ if command -v rg &>/dev/null; then
     extract_cmd="rg -o"
 fi
 
-# Use fd when available (2.3x faster than find!)
+# fd is faster than find
 if command -v fd &>/dev/null; then
     find_cmd="fd -t f"
 else
@@ -49,7 +49,7 @@ process_app() {
     local appNameNoExt="${appName%.app}"
 
     local runningStatus
-    # Use pgrep for accurate detection of running apps
+    
     # Check if ANY executable from the app's MacOS directory is running
     if pgrep -f "^$app/Contents/MacOS/" >/dev/null 2>&1; then
         runningStatus="🔵"

--- a/detect-running-affected-electron-apps.sh
+++ b/detect-running-affected-electron-apps.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # NOTE: You need to run this script from the terminal as ./detect-running-affected-electron-apps.sh, this one won't work if you simply paste the file contents into the terminal
 #
-# For 2x faster performance, install fd: brew install fd
 # Usage: ./detect-running-affected-electron-apps.sh [--fast]
 #   --fast: Only check standard locations (faster but may miss nested apps like Docker Desktop)
 
@@ -38,6 +37,10 @@ if command -v fd &>/dev/null; then
     find_cmd="fd -t f"
 else
     find_cmd="find"
+    if [[ "$FAST_MODE" != "true" ]]; then
+        echo "💡 Tip: Install fd for faster performance: brew install fd" >&2
+        echo "" >&2
+    fi
 fi
 
 process_app() {

--- a/detect-running-affected-electron-apps.sh
+++ b/detect-running-affected-electron-apps.sh
@@ -75,8 +75,18 @@ export SEARCH_CMD="$search_cmd"
 
 {
     mdfind "kMDItemFSName == '*.app'" 2>/dev/null | while IFS= read -r app; do
+        # Check standard location
         if [[ -f "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" ]]; then
             echo "$app"
+        fi
+        # Check for nested .app bundles in Contents/MacOS/
+        if [[ -d "$app/Contents/MacOS" ]]; then
+            find "$app/Contents/MacOS" -name "*.app" -type d -maxdepth 1 2>/dev/null | \
+            while IFS= read -r nested; do
+                if [[ -f "$nested/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" ]]; then
+                    echo "$nested"
+                fi
+            done
         fi
     done
     # -P 0 runs unlimited parallel processes, _ is placeholder for $0, {} becomes $1

--- a/detect-running-affected-electron-apps.sh
+++ b/detect-running-affected-electron-apps.sh
@@ -46,10 +46,8 @@ process_app() {
     local app="$1"
     local appName
     appName=$(basename "$app")
-    local appNameNoExt="${appName%.app}"
 
     local runningStatus
-    
     # Check if ANY executable from the app's MacOS directory is running
     if pgrep -f "^$app/Contents/MacOS/" >/dev/null 2>&1; then
         runningStatus="🔵"

--- a/detect-running-affected-electron-apps.sh
+++ b/detect-running-affected-electron-apps.sh
@@ -104,8 +104,7 @@ export FAST_MODE="$FAST_MODE"
         if [[ -f "$app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist" ]]; then
             echo "$app"
         elif [[ "$FAST_MODE" != "true" ]]; then
-            # Only do deep search if not in fast mode
-            # Search entire app bundle for nested Electron apps at any depth
+            # Also search entire app bundle for nested Electron apps at any depth (slow and expensive but accurate
             if [[ "$FIND_CMD" == "fd -t f" ]]; then
                 $FIND_CMD Info.plist "$app" 2>/dev/null | grep "Electron Framework" | $EXTRACT_CMD '^.*\.app'
             else
@@ -113,7 +112,6 @@ export FAST_MODE="$FAST_MODE"
             fi
         fi
     done
-    # -P 0 runs unlimited parallel processes, _ is placeholder for $0, {} becomes $1
 } | xargs -P 0 -I {} bash -c 'process_app "$1"' _ '{}' | {
     all_data=$(cat)
 


### PR DESCRIPTION
This PR fixes detection script based on comments from #7.
- Add nested .app bundle detection to find apps at any depth (e.g., Docker Desktop.app inside Docker.app)
- Add `--fast` flag for quick scans that only check standard locations (default is accurate by very slow)
- Installing fd and ripgrep makes accurate mode faster
- Fixes process grepping to be more accurate

## Usage
```bash
./detect-running-affected-electron-apps.sh --fast

# Full scan
./detect-running-affected-electron-apps.sh

# For best performance
brew install fd ripgrep
```